### PR TITLE
removing pre-releases from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "homepage": "https://github.com/canjs/can-define-validate-validatejs",
   "devDependencies": {
     "bit-docs": "^0.0.7",
-    "can-compute": "^3.1.0-pre.9",
+    "can-compute": "^3.1.0",
     "http-server": "^0.9.0",
     "jshint": "^2.9.4",
     "steal": "^1.0.8",
@@ -60,9 +60,9 @@
     "transpiler": "babel"
   },
   "dependencies": {
-    "can-define": "^1.2.0-pre.4",
-    "can-util": "^3.9.0-pre.4",
-    "can-validate": "^1.1.0-pre.0",
-    "can-validate-validatejs": "0.1.0-pre.0"
+    "can-define": "^1.2.0",
+    "can-util": "^3.9.0",
+    "can-validate": "^1.1.0",
+    "can-validate-validatejs": "0.1.0"
   }
 }


### PR DESCRIPTION
The purpose of this is so `can-validate-validatejs` will get the final version instead of the pre-release.